### PR TITLE
add tie result for hand_summary

### DIFF
--- a/deuces/evaluator.py
+++ b/deuces/evaluator.py
@@ -155,15 +155,17 @@ class Evaluator(object):
                 print "Player %d hand = %s, percentage rank among all hands = %f" % (counter, class_string, percentage)
 
                 counter += 1
+            winner = [j+1 for j, r in enumerate(ranks) if r == min(ranks)]
 
-            winner = ranks.index(min(ranks)) + 1
             if i != 2:
-                print "Player %d hand is currently winning." % winner
+                print "Player %d hand is currently winning." % winner[0]
             else:
                 print
                 print ("=" * line_length) + " HAND OVER " + ("=" * line_length) 
-                print "Player %d is the winner with a %s" % (winner, self.class_to_string(self.get_rank_class(self.evaluate(hands[winner-1], board))))
-            
+                if len(winner)==1:
+                    print "Player %d is the winner with a %s" % (winner[0], self.class_to_string(self.get_rank_class(self.evaluate(hands[winner[0]-1], board))))
+                else:
+                    print 'Winners are Player %s with a %s' % (', Player '.join(map(str, winner)), self.class_to_string(self.get_rank_class(self.evaluate(hands[winner[0]-1], board))))
             print
 
 


### PR DESCRIPTION
# When two hands have same rank (tie), the results choose the winner with smaller index instead of concluded as a tie game, for example:

Dealing a new hand...
The board:
  [ 9 ♠ ] , [ 2 ❤ ] , [ 6 ♦ ] , [ 7 ♠ ] , [ 4 ♣ ]  
Player 1's cards:
  [ 8 ♦ ] , [ Q ♣ ]  
Player 2's cards:
  [ 8 ♣ ] , [ Q ♠ ]  
Player 1 hand rank = 7147 (High Card)
Player 2 hand rank = 7147 (High Card)
========== FLOP ==========
Player 1 hand = High Card, percentage rank among all hands = 0.958858
Player 2 hand = High Card, percentage rank among all hands = 0.958858
Player 1 hand is currently winning.

========== TURN ==========
Player 1 hand = High Card, percentage rank among all hands = 0.957786
Player 2 hand = High Card, percentage rank among all hands = 0.957786
Player 1 hand is currently winning.

========== RIVER ==========
Player 1 hand = High Card, percentage rank among all hands = 0.957786
Player 2 hand = High Card, percentage rank among all hands = 0.957786

========== HAND OVER ==========
Player 1 is the winner with a High Card
# 

This was fixed and will concluded as multiple winners in the above case.
